### PR TITLE
chore: lower minimum Dart SDK to 3.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ documentation, and more).
 
 ### ⚙️ Requirements
 
-- [Dart](https://dart.dev) version `3.11` or higher
+- [Dart](https://dart.dev) version `3.10` or higher
 - [git-cliff](https://git-cliff.org) for generating changelogs
 - [Lefthook](https://github.com/evilmartians/lefthook) for managing Git hooks
 

--- a/examples/dartnote/pubspec.yaml
+++ b/examples/dartnote/pubspec.yaml
@@ -2,7 +2,7 @@ name: dartnote
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -10,3 +10,6 @@ dependencies:
   ffi: ^2.2.0
   ffi_leak_tracker: ^0.1.0
   win32: ^6.0.0
+
+dev_dependencies:
+  halildurmus_lints: ^1.1.0

--- a/examples/explorer/pubspec.yaml
+++ b/examples/explorer/pubspec.yaml
@@ -2,7 +2,7 @@ name: win32_explorer
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -20,7 +20,7 @@ dependencies:
   win32: ^6.0.0
 
 dev_dependencies:
-  halildurmus_lints: ^2.0.0
+  halildurmus_lints: ^1.1.0
 
 flutter:
   uses-material-design: true

--- a/examples/manifest/pubspec.yaml
+++ b/examples/manifest/pubspec.yaml
@@ -2,10 +2,13 @@ name: manifest
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
   ffi: ^2.2.0
   win32: ^6.0.0
+
+dev_dependencies:
+  halildurmus_lints: ^1.1.0

--- a/examples/service_manager_cli/pubspec.yaml
+++ b/examples/service_manager_cli/pubspec.yaml
@@ -2,7 +2,7 @@ name: service_manager_cli
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -12,7 +12,7 @@ dependencies:
   win32: ^6.0.0
 
 dev_dependencies:
-  halildurmus_lints: ^2.0.0
+  halildurmus_lints: ^1.1.0
 
 executables:
   service_manager_cli:

--- a/examples/snake/pubspec.yaml
+++ b/examples/snake/pubspec.yaml
@@ -2,7 +2,7 @@ name: snake
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -10,3 +10,6 @@ dependencies:
   ffi: ^2.2.0
   ffi_leak_tracker: ^0.1.0
   win32: ^6.0.0
+
+dev_dependencies:
+  halildurmus_lints: ^1.1.0

--- a/examples/system_tray_icon/pubspec.yaml
+++ b/examples/system_tray_icon/pubspec.yaml
@@ -2,7 +2,7 @@ name: system_tray_icon
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -10,3 +10,6 @@ dependencies:
   ffi: ^2.2.0
   ffi_leak_tracker: ^0.1.0
   win32: ^6.0.0
+
+dev_dependencies:
+  halildurmus_lints: ^1.1.0

--- a/examples/task_dialog/pubspec.yaml
+++ b/examples/task_dialog/pubspec.yaml
@@ -2,10 +2,13 @@ name: task_dialog
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
   ffi: ^2.2.0
   win32: ^6.0.0
+
+dev_dependencies:
+  halildurmus_lints: ^1.1.0

--- a/examples/task_manager/pubspec.yaml
+++ b/examples/task_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: Task Manager
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -15,7 +15,7 @@ dependencies:
   win32: ^6.0.0
 
 dev_dependencies:
-  halildurmus_lints: ^2.0.0
+  halildurmus_lints: ^1.1.0
 
 flutter:
   uses-material-design: true

--- a/examples/tetris/pubspec.yaml
+++ b/examples/tetris/pubspec.yaml
@@ -2,7 +2,7 @@ name: tetris
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -10,3 +10,6 @@ dependencies:
   ffi: ^2.2.0
   ffi_leak_tracker: ^0.1.0
   win32: ^6.0.0
+
+dev_dependencies:
+  halildurmus_lints: ^1.1.0

--- a/examples/usb_drive_monitor/pubspec.yaml
+++ b/examples/usb_drive_monitor/pubspec.yaml
@@ -2,7 +2,7 @@ name: usb_drive_monitor
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -10,3 +10,6 @@ dependencies:
   ffi: ^2.2.0
   ffi_leak_tracker: ^0.1.0
   win32: ^6.0.0
+
+dev_dependencies:
+  halildurmus_lints: ^1.1.0

--- a/packages/ffi_leak_tracker/pubspec.yaml
+++ b/packages/ffi_leak_tracker/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - ffi
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -21,4 +21,5 @@ dependencies:
 
 dev_dependencies:
   checks: ^0.3.1
+  halildurmus_lints: ^1.1.0
   test: ^1.29.0

--- a/packages/filepicker_windows/example/wallpaper/pubspec.yaml
+++ b/packages/filepicker_windows/example/wallpaper/pubspec.yaml
@@ -2,7 +2,7 @@ name: wallpaper
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -15,7 +15,7 @@ dependencies:
   win32: ^6.0.0
 
 dev_dependencies:
-  halildurmus_lints: ^2.0.0
+  halildurmus_lints: ^1.1.0
 
 flutter:
   uses-material-design: true

--- a/packages/filepicker_windows/pubspec.yaml
+++ b/packages/filepicker_windows/pubspec.yaml
@@ -14,7 +14,7 @@ topics:
   - windows
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 platforms:
   windows:
@@ -23,11 +23,11 @@ resolution: workspace
 
 dependencies:
   ffi: ^2.2.0
-  ffi_leak_tracker: ^0.1.0
+  ffi_leak_tracker: ^0.1.1
   win32: ^6.0.0
 
 dev_dependencies:
   checks: ^0.3.1
-  halildurmus_hooks: ^0.1.1
-  halildurmus_lints: ^2.0.0
+  halildurmus_hooks: ^0.1.0
+  halildurmus_lints: ^1.1.0
   test: ^1.29.0

--- a/packages/generator/pubspec.yaml
+++ b/packages/generator/pubspec.yaml
@@ -3,7 +3,7 @@ description: Generates Win32 and COM API projections from Windows Metadata.
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -55,7 +55,7 @@ dev_dependencies:
   halildurmus_hooks: ^0.1.1
 
   # Help ensure that the code is well-written.
-  halildurmus_lints: ^2.0.0
+  halildurmus_lints: ^1.1.0
 
   # Running the test suite.
   test: ^1.29.0

--- a/packages/win32/hook/build.dart
+++ b/packages/win32/hook/build.dart
@@ -65,7 +65,7 @@ Logger createDefaultLogger() {
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (!input.config.buildCodeAssets) return;
-    if (input.config.code.targetOS != OS.windows) return;
+    if (input.config.code.targetOS != .windows) return;
 
     final packageName = input.packageName;
     final cbuilder = CBuilder.library(
@@ -79,7 +79,7 @@ void main(List<String> args) async {
     String normalizeDynamicLibraryName(String library) =>
         library.replaceAll('-', '_').split('.').first;
 
-    CodeAsset createCodeAsset(String library) => CodeAsset(
+    CodeAsset createCodeAsset(String library) => .new(
       package: packageName,
       name: 'src/win32/${normalizeDynamicLibraryName(library)}.g.dart',
       linkMode: DynamicLoadingSystem(.file(library)),

--- a/packages/win32/pubspec.yaml
+++ b/packages/win32/pubspec.yaml
@@ -24,7 +24,7 @@ topics:
   - ffi
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -35,7 +35,7 @@ platforms:
 dependencies:
   code_assets: ^1.0.0
   ffi: ^2.2.0
-  ffi_leak_tracker: ^0.1.0
+  ffi_leak_tracker: ^0.1.1
   hooks: ^1.0.0
   logging: ^1.3.0
   meta: ^1.17.0
@@ -52,7 +52,7 @@ dev_dependencies:
   halildurmus_hooks: ^0.1.1
 
   # Help ensure that the code is well-written.
-  halildurmus_lints: ^2.0.0
+  halildurmus_lints: ^1.1.0
 
   # Used for joining paths.
   path: ^1.9.1

--- a/packages/win32_clipboard/pubspec.yaml
+++ b/packages/win32_clipboard/pubspec.yaml
@@ -14,7 +14,7 @@ topics:
   - windows
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 platforms:
   windows:
@@ -29,6 +29,6 @@ dependencies:
 
 dev_dependencies:
   checks: ^0.3.1
-  halildurmus_hooks: ^0.1.1
-  halildurmus_lints: ^2.0.0
+  halildurmus_hooks: ^0.1.0
+  halildurmus_lints: ^1.1.0
   test: ^1.29.0

--- a/packages/win32_gamepad/example/inspector/pubspec.yaml
+++ b/packages/win32_gamepad/example/inspector/pubspec.yaml
@@ -2,7 +2,7 @@ name: inspector
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 resolution: workspace
 
@@ -17,4 +17,4 @@ flutter:
   uses-material-design: true
 
 dev_dependencies:
-  halildurmus_lints: ^2.0.0
+  halildurmus_lints: ^1.1.0

--- a/packages/win32_gamepad/pubspec.yaml
+++ b/packages/win32_gamepad/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
   - windows
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 platforms:
   windows:
@@ -28,6 +28,6 @@ dependencies:
 
 dev_dependencies:
   checks: ^0.3.1
-  halildurmus_hooks: ^0.1.1
-  halildurmus_lints: ^2.0.0
+  halildurmus_hooks: ^0.1.0
+  halildurmus_lints: ^1.1.0
   test: ^1.29.0

--- a/packages/win32_registry/pubspec.yaml
+++ b/packages/win32_registry/pubspec.yaml
@@ -14,7 +14,7 @@ topics:
   - windows
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 platforms:
   windows:
@@ -24,12 +24,12 @@ resolution: workspace
 dependencies:
   collection: ^1.19.1
   ffi: ^2.2.0
-  ffi_leak_tracker: ^0.1.0
+  ffi_leak_tracker: ^0.1.1
   meta: ^1.17.0
   win32: ^6.0.0
 
 dev_dependencies:
   checks: ^0.3.1
-  halildurmus_hooks: ^0.1.1
-  halildurmus_lints: ^2.0.0
+  halildurmus_hooks: ^0.1.0
+  halildurmus_lints: ^1.1.0
   test: ^1.29.0

--- a/packages/win32_runner/pubspec.yaml
+++ b/packages/win32_runner/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - windows
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 platforms:
   windows:
@@ -28,6 +28,6 @@ dependencies:
 
 dev_dependencies:
   checks: ^0.3.1
-  halildurmus_hooks: ^0.1.1
-  halildurmus_lints: ^2.0.0
+  halildurmus_hooks: ^0.1.0
+  halildurmus_lints: ^1.1.0
   test: ^1.29.0

--- a/packages/winmd/lib/src/writer/metadata_writer.dart
+++ b/packages/winmd/lib/src/writer/metadata_writer.dart
@@ -305,7 +305,7 @@ final class MetadataWriter {
   FieldIndex writeField({
     required String name,
     required MetadataType signature,
-    FieldAttributes flags = const .new(0),
+    FieldAttributes flags = FieldAttributes.compilerControlled,
   }) {
     final table = _tableStream[.field];
     final index = FieldIndex(table.length);
@@ -325,7 +325,7 @@ final class MetadataWriter {
     required String name,
     required Implementation implementation,
     String? namespace,
-    TypeAttributes flags = const .new(0),
+    TypeAttributes flags = TypeAttributes.notPublic,
   }) {
     final table = _tableStream[.exportedType];
     final index = ExportedTypeIndex(table.length);
@@ -368,7 +368,7 @@ final class MetadataWriter {
   FileIndex writeFile({
     required String name,
     required Uint8List hashValue,
-    FileAttributes flags = const .new(0),
+    FileAttributes flags = FileAttributes.containsMetadata,
   }) {
     final table = _tableStream[.file];
     final index = FileIndex(table.length);
@@ -387,7 +387,7 @@ final class MetadataWriter {
     required int number,
     required TypeOrMethodDef owner,
     required String name,
-    GenericParamAttributes flags = const .new(0),
+    GenericParamAttributes flags = GenericParamAttributes.none,
     TypeDefOrRef? constraint,
   }) {
     final genericParam = GenericParam(
@@ -407,7 +407,7 @@ final class MetadataWriter {
     required MethodDefIndex method,
     required String importName,
     required String importScope,
-    PInvokeAttributes flags = const .new(0),
+    PInvokeAttributes flags = PInvokeAttributes.charSetNotSpec,
   }) {
     final scope = writeModuleRef(name: importScope);
     _tableStream[.implMap].add(
@@ -479,8 +479,8 @@ final class MetadataWriter {
   MethodDefIndex writeMethodDef({
     required String name,
     int rva = 0,
-    MethodImplAttributes implFlags = const .new(0),
-    MethodAttributes flags = const .new(0),
+    MethodImplAttributes implFlags = MethodImplAttributes.il,
+    MethodAttributes flags = MethodAttributes.compilerControlled,
     MethodSignature signature = const .new(),
   }) {
     final table = _tableStream[.methodDef];
@@ -642,7 +642,7 @@ final class MetadataWriter {
   TypeDefIndex writeTypeDef({
     required String namespace,
     required String name,
-    TypeAttributes flags = const .new(0),
+    TypeAttributes flags = TypeAttributes.notPublic,
     TypeDefOrRef extends$ = .none,
   }) {
     // Track root namespaces like "Windows.Foundation".

--- a/packages/winmd/lib/src/writer/table/exported_type.dart
+++ b/packages/winmd/lib/src/writer/table/exported_type.dart
@@ -27,7 +27,7 @@ final class ExportedType implements Row {
     required this.typeDefId,
     required this.typeName,
     required this.implementation,
-    this.flags = const TypeAttributes(0),
+    this.flags = TypeAttributes.notPublic,
     this.typeNamespace = const StringIndex(0),
   });
 

--- a/packages/winmd/lib/src/writer/table/file.dart
+++ b/packages/winmd/lib/src/writer/table/file.dart
@@ -22,7 +22,7 @@ final class File implements Row {
   const File({
     required this.name,
     required this.hashValue,
-    this.flags = const FileAttributes(0),
+    this.flags = FileAttributes.containsMetadata,
   });
 
   final FileAttributes flags;

--- a/packages/winmd/lib/src/writer/table/generic_param.dart
+++ b/packages/winmd/lib/src/writer/table/generic_param.dart
@@ -25,7 +25,7 @@ final class GenericParam implements Row {
     required this.number,
     required this.owner,
     required this.name,
-    this.flags = const GenericParamAttributes(0),
+    this.flags = GenericParamAttributes.none,
   });
 
   final int number;

--- a/packages/winmd/lib/src/writer/table/impl_map.dart
+++ b/packages/winmd/lib/src/writer/table/impl_map.dart
@@ -26,7 +26,7 @@ final class ImplMap implements Row {
     required this.memberForwarded,
     required this.importName,
     required this.importScope,
-    this.mappingFlags = const PInvokeAttributes(0),
+    this.mappingFlags = PInvokeAttributes.charSetNotSpec,
   });
 
   final PInvokeAttributes mappingFlags;

--- a/packages/winmd/lib/src/writer/table/method_def.dart
+++ b/packages/winmd/lib/src/writer/table/method_def.dart
@@ -28,8 +28,8 @@ final class MethodDef implements Row {
     required this.name,
     required this.signature,
     required this.paramList,
-    this.implFlags = const MethodImplAttributes(0),
-    this.flags = const MethodAttributes(0),
+    this.implFlags = MethodImplAttributes.il,
+    this.flags = MethodAttributes.compilerControlled,
   });
 
   final int rva;

--- a/packages/winmd/lib/src/writer/table/type_def.dart
+++ b/packages/winmd/lib/src/writer/table/type_def.dart
@@ -29,7 +29,7 @@ final class TypeDef implements Row {
     required this.extends$,
     required this.fieldList,
     required this.methodList,
-    this.flags = const TypeAttributes(0),
+    this.flags = TypeAttributes.notPublic,
     this.namespace = const StringIndex(0),
   });
 

--- a/packages/winmd/pubspec.yaml
+++ b/packages/winmd/pubspec.yaml
@@ -14,7 +14,7 @@ topics:
   - metadata
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 platforms:
   linux:
@@ -34,6 +34,6 @@ dependencies:
 
 dev_dependencies:
   checks: ^0.3.1
-  halildurmus_hooks: ^0.1.1
-  halildurmus_lints: ^2.0.0
+  halildurmus_hooks: ^0.1.0
+  halildurmus_lints: ^1.1.0
   test: ^1.29.0

--- a/packages/winmd/test/writer/metadata_writer_test.dart
+++ b/packages/winmd/test/writer/metadata_writer_test.dart
@@ -78,7 +78,7 @@ void main() {
       check(typeDef.namespace).isEmpty();
       check(typeDef.name).equals('<Module>');
       check(typeDef.extends$).isNull();
-      check(typeDef.flags).equals(const .new(0));
+      check(typeDef.flags).equals(TypeAttributes.notPublic);
     });
 
     test('Class', () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,20 +2,40 @@ name: win32_workspace
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.10.0
 
 workspace:
-  - examples/*
-  - packages/*
+  # - examples/*
+  - examples/dartnote
+  - examples/explorer
+  - examples/manifest
+  - examples/service_manager_cli
+  - examples/snake
+  - examples/system_tray_icon
+  - examples/task_dialog
+  - examples/task_manager
+  - examples/tetris
+  - examples/usb_drive_monitor
+
+  # - packages/*
+  - packages/ffi_leak_tracker
+  - packages/filepicker_windows
+  - packages/generator
+  - packages/win32
+  - packages/win32_clipboard
+  - packages/win32_gamepad
+  - packages/win32_registry
+  - packages/win32_runner
+  - packages/winmd
   - packages/filepicker_windows/example/wallpaper
   - packages/win32_gamepad/example/inspector
 
 dev_dependencies:
   args: ^2.7.0
   ffi: ^2.2.0
-  ffi_leak_tracker: ^0.1.0
-  halildurmus_hooks: ^0.1.1
-  halildurmus_lints: ^2.0.0
+  ffi_leak_tracker: ^0.1.1
+  halildurmus_hooks: ^0.1.0
+  halildurmus_lints: ^1.1.0
   melos: ^7.4.0
   path: ^1.9.1
   win32: ^6.0.0

--- a/website/docs/community/contributing.md
+++ b/website/docs/community/contributing.md
@@ -40,7 +40,7 @@ We strive to maintain a welcoming and inclusive community, so please read our
 
 ### ⚙️ Requirements
 
-- [Dart](https://dart.dev) version `3.11` or higher
+- [Dart](https://dart.dev) version `3.10` or higher
 - [Melos](https://pub.dev/packages/melos) for managing the monorepo
 - [git-cliff](https://git-cliff.org) for generating changelogs
 - [Lefthook](https://github.com/evilmartians/lefthook) for managing Git hooks


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the
  title.

  Please look at the following checklist to ensure that your PR can be accepted
  quickly:
-->

## Description

Lowers the minimum Dart SDK requirement to 3.10 to improve compatibility with other packages.

3.10 is the lowest supported version due to the use of **hooks**, which became stable in this release.

## Related Issue

Bug: #1052 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [ ] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [x] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
