### PR TITLE
feat(win32): add `OsVersion` class to reliably detect Windows version

### DIFF
--- a/examples/explorer/lib/main.dart
+++ b/examples/explorer/lib/main.dart
@@ -39,7 +39,7 @@ class MainPageState extends State<MainPage> {
 
   @override
   void initState() {
-    showRoundedCornerSwitch = IsWindows11OrGreater();
+    showRoundedCornerSwitch = OsVersion.current >= .win11;
     super.initState();
   }
 

--- a/examples/version.dart
+++ b/examples/version.dart
@@ -1,0 +1,24 @@
+// Demonstrates querying the running Windows version and comparing against
+// well-known baselines.
+
+import 'package:win32/win32.dart';
+
+void main() {
+  // Display the current version and edition, and compare against baselines.
+  final current = OsVersion.current;
+  print('Running on:     $current');
+  print('Revision:       ${OsVersion.revision}');
+  print('Server edition: ${OsVersion.isServer}');
+  print('-' * 40);
+  print('Windows 10 or later: ${current >= .win10}');
+  print('Windows 11 or later: ${current >= .win11}');
+  print('-' * 40);
+
+  // Guard a feature that requires a minimum version.
+  if (current >= .win10v1607) {
+    // e.g., GetSystemCpuSetInformation API is available from 1607 onwards.
+    print('GetSystemCpuSetInformation API: available');
+  } else {
+    print('GetSystemCpuSetInformation API: not available on this version');
+  }
+}

--- a/packages/win32/example/README.md
+++ b/packages/win32/example/README.md
@@ -38,6 +38,7 @@ pipes, and the registry.
 | [modules.dart]        | Enumerating loaded modules                        |
 | [pipe.dart]           | Named pipes and IPC                               |
 | [registry.dart]       | Querying and enumerating registry keys            |
+| [version.dart]        | Querying the running Windows version              |
 | [vt.dart]             | Virtual terminal (ANSI) sequences                 |
 | [wsl.dart]            | Accessing WSL instance information                |
 
@@ -51,6 +52,7 @@ pipes, and the registry.
 [modules.dart]: https://github.com/halildurmus/win32/blob/main/examples/modules.dart
 [pipe.dart]: https://github.com/halildurmus/win32/blob/main/examples/pipe.dart
 [registry.dart]: https://github.com/halildurmus/win32/blob/main/examples/registry.dart
+[version.dart]: https://github.com/halildurmus/win32/blob/main/examples/version.dart
 [vt.dart]: https://github.com/halildurmus/win32/blob/main/examples/vt.dart
 [wsl.dart]: https://github.com/halildurmus/win32/blob/main/examples/wsl.dart
 

--- a/packages/win32/lib/src/functions.dart
+++ b/packages/win32/lib/src/functions.dart
@@ -7,12 +7,10 @@
 
 import 'dart:ffi';
 
-import 'package:ffi/ffi.dart';
-
 import 'constants.g.dart';
 import 'structs.dart';
 import 'structs.g.dart';
-import 'win32/ntdll.g.dart';
+import 'version.dart';
 
 /// Retrieves the current value of a specified Desktop Window Manager (DWM)
 /// attribute applied to a window.
@@ -58,38 +56,8 @@ external int _SetWindowCompositionAttribute(
   Pointer<WINDOWCOMPOSITIONATTRIBDATA> pwcad,
 );
 
-/// Whether the OS version is Windows 10 (build 19041) or greater.
-bool IsWindows10OrGreater() => using((arena) {
-  final osvi = arena<OSVERSIONINFO>()
-    ..ref.dwOSVersionInfoSize = sizeOf<OSVERSIONINFO>();
-  final status = RtlGetVersion(osvi);
-  if (status.isError) return false;
+/// Whether the OS version is Windows 10 or greater.
+bool IsWindows10OrGreater() => OsVersion.current >= OsVersion.win10;
 
-  if (osvi.ref case OSVERSIONINFO(
-    :final dwMajorVersion,
-    dwMinorVersion: 0,
-    :final dwBuildNumber,
-  ) when dwMajorVersion >= 10 && dwBuildNumber >= 19041) {
-    return true;
-  }
-
-  return false;
-});
-
-/// Whether the OS version is Windows 11 (build 22000) or greater.
-bool IsWindows11OrGreater() => using((arena) {
-  final osvi = arena<OSVERSIONINFO>()
-    ..ref.dwOSVersionInfoSize = sizeOf<OSVERSIONINFO>();
-  final status = RtlGetVersion(osvi);
-  if (status.isError) return false;
-
-  if (osvi.ref case OSVERSIONINFO(
-    :final dwMajorVersion,
-    dwMinorVersion: 0,
-    :final dwBuildNumber,
-  ) when dwMajorVersion >= 10 && dwBuildNumber >= 22000) {
-    return true;
-  }
-
-  return false;
-});
+/// Whether the OS version is Windows 11 or greater.
+bool IsWindows11OrGreater() => OsVersion.current >= OsVersion.win11;

--- a/packages/win32/lib/src/version.dart
+++ b/packages/win32/lib/src/version.dart
@@ -1,0 +1,260 @@
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+import 'constants.g.dart';
+import 'enums.g.dart';
+import 'extensions/arena.dart';
+import 'structs.g.dart';
+import 'types.dart';
+import 'win32/advapi32.g.dart';
+import 'win32/ntdll.g.dart';
+
+/// Version information for the currently running Windows operating system.
+///
+/// Use [OsVersion.current] to retrieve the running version, and the relational
+/// operators (`<`, `<=`, `>=`, `>`) to range-check it against a known baseline.
+///
+/// ```dart
+/// final current = OsVersion.current;
+/// if (current >= .win11) {
+///   print('Windows 11 or later');
+/// } else if (current >= .win10) {
+///   print('Windows 10');
+/// } else {
+///   print('Unsupported OS');
+/// }
+/// ```
+///
+/// See also:
+/// - [OsVersion.isServer] to distinguish server from workstation editions.
+/// - [OsVersion.revision] for the Update Build Revision (UBR) patch number.
+final class OsVersion implements Comparable<OsVersion> {
+  /// Creates an [OsVersion] with the given components.
+  const OsVersion({
+    this.major = 0,
+    this.minor = 0,
+    this.pack = 0,
+    this.build = 0,
+  });
+
+  /// Windows XP (5.1, build 2600).
+  static const xp = OsVersion(major: 5, minor: 1, build: 2600);
+
+  /// Windows XP Service Pack 1 (5.1, build 2600).
+  static const xpSp1 = OsVersion(major: 5, minor: 1, pack: 1, build: 2600);
+
+  /// Windows XP Service Pack 2 (5.1, build 2600).
+  static const xpSp2 = OsVersion(major: 5, minor: 1, pack: 2, build: 2600);
+
+  /// Windows XP Service Pack 3 (5.1, build 2600).
+  static const xpSp3 = OsVersion(major: 5, minor: 1, pack: 3, build: 2600);
+
+  /// Windows Vista (6.0, build 6000).
+  static const vista = OsVersion(major: 6, build: 6000);
+
+  /// Windows Vista Service Pack 1 (6.0, build 6001).
+  static const vistaSp1 = OsVersion(major: 6, pack: 1, build: 6001);
+
+  /// Windows Vista Service Pack 2 (6.0, build 6002).
+  static const vistaSp2 = OsVersion(major: 6, pack: 2, build: 6002);
+
+  /// Windows 7 (6.1, build 7600).
+  static const win7 = OsVersion(major: 6, minor: 1, build: 7600);
+
+  /// Windows 7 Service Pack 1 (6.1, build 7601).
+  static const win7Sp1 = OsVersion(major: 6, minor: 1, pack: 1, build: 7601);
+
+  /// Windows 8 (6.2, build 9200).
+  static const win8 = OsVersion(major: 6, minor: 2, build: 9200);
+
+  /// Windows 8.1 (6.3, build 9600).
+  static const win81 = OsVersion(major: 6, minor: 3, build: 9600);
+
+  /// Windows 10, version 1507 — the initial release (build 10240).
+  static const win10 = OsVersion(major: 10, build: 10240);
+
+  /// Windows 10, version 1511 — November Update (build 10586).
+  static const win10v1511 = OsVersion(major: 10, build: 10586);
+
+  /// Windows 10, version 1607 — Anniversary Update (build 14393).
+  static const win10v1607 = OsVersion(major: 10, build: 14393);
+
+  /// Windows 10, version 1703 — Creators Update (build 15063).
+  static const win10v1703 = OsVersion(major: 10, build: 15063);
+
+  /// Windows 10, version 1709 — Fall Creators Update (build 16299).
+  static const win10v1709 = OsVersion(major: 10, build: 16299);
+
+  /// Windows 10, version 1803 — April 2018 Update (build 17134).
+  static const win10v1803 = OsVersion(major: 10, build: 17134);
+
+  /// Windows 10, version 1809 — October 2018 Update (build 17763).
+  static const win10v1809 = OsVersion(major: 10, build: 17763);
+
+  /// Windows 10, version 1903 — May 2019 Update (build 18362).
+  static const win10v1903 = OsVersion(major: 10, build: 18362);
+
+  /// Windows 10, version 1909 — November 2019 Update (build 18363).
+  static const win10v1909 = OsVersion(major: 10, build: 18363);
+
+  /// Windows 10, version 2004 — May 2020 Update (build 19041).
+  static const win10v2004 = OsVersion(major: 10, build: 19041);
+
+  /// Windows 10, version 20H2 — October 2020 Update (build 19042).
+  static const win10v20H2 = OsVersion(major: 10, build: 19042);
+
+  /// Windows 10, version 21H1 — May 2021 Update (build 19043).
+  static const win10v21H1 = OsVersion(major: 10, build: 19043);
+
+  /// Windows 10, version 21H2 — November 2021 Update (build 19044).
+  static const win10v21H2 = OsVersion(major: 10, build: 19044);
+
+  /// Windows 10, version 22H2 — October 2022 Update (build 19045).
+  ///
+  /// This is the final feature update for Windows 10.
+  static const win10v22H2 = OsVersion(major: 10, build: 19045);
+
+  /// Windows Server 2022 (build 20348).
+  static const winServer2022 = OsVersion(major: 10, build: 20348);
+
+  /// Windows 11, version 21H2 — the initial release (build 22000).
+  static const win11 = OsVersion(major: 10, build: 22000);
+
+  /// Windows 11, version 22H2 — 2022 Update (build 22621).
+  static const win11v22H2 = OsVersion(major: 10, build: 22621);
+
+  /// Windows 11, version 23H2 — 2023 Update (build 22631).
+  static const win11v23H2 = OsVersion(major: 10, build: 22631);
+
+  /// Windows 11, version 24H2 — 2024 Update (build 26100).
+  static const win11v24H2 = OsVersion(major: 10, build: 26100);
+
+  /// Windows 11, version 25H2 — 2025 Update (build 26200).
+  static const win11v25H2 = OsVersion(major: 10, build: 26200);
+
+  /// Windows 11, version 26H1 (build 28000).
+  static const win11v26H1 = OsVersion(major: 10, build: 28000);
+
+  /// The version information of the currently running operating system.
+  ///
+  /// Calls [RtlGetVersion] internally, which — unlike the deprecated
+  /// `GetVersionEx` — always returns the true version regardless of any
+  /// application-compatibility shims.
+  static OsVersion get current => using((arena) {
+    final info = arena<OSVERSIONINFOEX>()
+      ..ref.dwOSVersionInfoSize = sizeOf<OSVERSIONINFOEX>();
+    RtlGetVersion(info.cast());
+    final OSVERSIONINFOEX(
+      :dwMajorVersion,
+      :dwMinorVersion,
+      :wServicePackMajor,
+      :dwBuildNumber,
+    ) = info.ref;
+    return .new(
+      major: dwMajorVersion,
+      minor: dwMinorVersion,
+      pack: wServicePackMajor,
+      build: dwBuildNumber,
+    );
+  });
+
+  /// Whether the currently running operating system is a Windows Server
+  /// edition.
+  static bool get isServer => using((arena) {
+    final info = arena<OSVERSIONINFOEX>()
+      ..ref.dwOSVersionInfoSize = sizeOf<OSVERSIONINFOEX>();
+    RtlGetVersion(info.cast());
+    return info.ref.wProductType != VER_NT_WORKSTATION;
+  });
+
+  /// The Update Build Revision (UBR) of the operating system.
+  ///
+  /// This is the incremental patch number applied on top of [build] by Windows
+  /// Update, stored under
+  /// `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\UBR`.
+  ///
+  /// Returns `0` if the registry value cannot be read.
+  static int get revision => using((arena) {
+    final data = arena<DWORD>();
+    final dataSize = arena<DWORD>()..value = sizeOf<DWORD>();
+    final result = RegGetValue(
+      HKEY_LOCAL_MACHINE,
+      arena.pcwstr(r'SOFTWARE\Microsoft\Windows NT\CurrentVersion'),
+      arena.pcwstr('UBR'),
+      RRF_RT_REG_DWORD,
+      null,
+      data.cast(),
+      dataSize,
+    );
+    return result == ERROR_SUCCESS ? data.value : 0;
+  });
+
+  /// The major version number of the operating system.
+  ///
+  /// For example, `10` for both Windows 10 and Windows 11.
+  final int major;
+
+  /// The minor version number of the operating system.
+  ///
+  /// Typically `0` for all modern Windows releases (Vista and later).
+  final int minor;
+
+  /// The major version number of the latest service pack installed on the
+  /// system.
+  ///
+  /// Service packs were discontinued after Windows 7, so this is `0` on all
+  /// modern systems.
+  final int pack;
+
+  /// The build number of the operating system.
+  ///
+  /// This is the most reliable way to distinguish Windows 10 from Windows 11:
+  /// builds `>= 22000` indicate Windows 11.
+  final int build;
+
+  /// Returns a copy of this [OsVersion] with the given fields replaced.
+  OsVersion copyWith({int? major, int? minor, int? pack, int? build}) => .new(
+    major: major ?? this.major,
+    minor: minor ?? this.minor,
+    pack: pack ?? this.pack,
+    build: build ?? this.build,
+  );
+
+  /// Compares this version to [other] using lexicographic field order:
+  /// [major], [minor], [pack], then [build].
+  @override
+  int compareTo(OsVersion other) {
+    if (major != other.major) return major.compareTo(other.major);
+    if (minor != other.minor) return minor.compareTo(other.minor);
+    if (pack != other.pack) return pack.compareTo(other.pack);
+    return build.compareTo(other.build);
+  }
+
+  /// Whether this version is greater than or equal to [other].
+  bool operator >=(OsVersion other) => compareTo(other) >= 0;
+
+  /// Whether this version is less than or equal to [other].
+  bool operator <=(OsVersion other) => compareTo(other) <= 0;
+
+  /// Whether this version is strictly greater than [other].
+  bool operator >(OsVersion other) => compareTo(other) > 0;
+
+  /// Whether this version is strictly less than [other].
+  bool operator <(OsVersion other) => compareTo(other) < 0;
+
+  @override
+  bool operator ==(Object other) =>
+      other is OsVersion &&
+      major == other.major &&
+      minor == other.minor &&
+      pack == other.pack &&
+      build == other.build;
+
+  @override
+  int get hashCode => Object.hash(major, minor, pack, build);
+
+  @override
+  String toString() =>
+      'OsVersion(major: $major, minor: $minor, pack: $pack, build: $build)';
+}

--- a/packages/win32/lib/win32.dart
+++ b/packages/win32/lib/win32.dart
@@ -75,5 +75,6 @@ export 'src/structs.g.dart';
 export 'src/types.dart';
 export 'src/utils.dart';
 export 'src/variant.dart';
+export 'src/version.dart';
 export 'src/win32_error.dart';
 export 'src/win32_result.dart';

--- a/packages/win32/test/version_test.dart
+++ b/packages/win32/test/version_test.dart
@@ -1,0 +1,107 @@
+@TestOn('windows')
+library;
+
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
+import 'package:win32/win32.dart';
+
+import 'helpers.dart';
+
+void main() {
+  group('OsVersion', () {
+    test('equality', () {
+      check(OsVersion.win10v2004).equals(.win10v2004);
+    });
+
+    test('current', () {
+      final current = OsVersion.current;
+      check(current.major).isGreaterOrEqual(10);
+      check(current.minor).isGreaterOrEqual(0);
+      check(current.pack).isGreaterOrEqual(0);
+      check(current.build).isGreaterOrEqual(19041);
+    });
+
+    test('isServer returns without throwing', () {
+      check(() => OsVersion.isServer).returnsNormally();
+    });
+
+    test('revision returns non-zero on a real machine', () {
+      check(OsVersion.revision).isNonZero();
+    });
+
+    test('major version comparison', () {
+      const v = OsVersion(major: 10);
+      check(v >= const .new(major: 9)).isTrue();
+      check(v >= const .new(major: 10)).isTrue();
+      check(v >= const .new(major: 11)).isFalse();
+    });
+
+    test('minor version comparison', () {
+      const v = OsVersion(major: 10, minor: 100);
+      check(v >= const .new(major: 10, minor: 99)).isTrue();
+      check(v >= const .new(major: 10, minor: 100)).isTrue();
+      check(v >= const .new(major: 10, minor: 101)).isFalse();
+    });
+
+    test('pack version comparison', () {
+      const v = OsVersion(major: 10, minor: 100, pack: 1000);
+      check(v >= const .new(major: 10, minor: 100, pack: 999)).isTrue();
+      check(v >= const .new(major: 10, minor: 100, pack: 1000)).isTrue();
+      check(v >= const .new(major: 10, minor: 100, pack: 1001)).isFalse();
+    });
+
+    test('build number comparison', () {
+      const v = OsVersion(major: 10, minor: 100, pack: 1000, build: 10000);
+      check(
+        v >= const .new(major: 10, minor: 100, pack: 1000, build: 9999),
+      ).isTrue();
+      check(
+        v >= const .new(major: 10, minor: 100, pack: 1000, build: 10000),
+      ).isTrue();
+      check(
+        v >= const .new(major: 10, minor: 100, pack: 1000, build: 10001),
+      ).isFalse();
+    });
+
+    test('version constants are in ascending order', () {
+      const versions = <OsVersion>[
+        .xp,
+        .xpSp1,
+        .xpSp2,
+        .xpSp3,
+        .vista,
+        .vistaSp1,
+        .vistaSp2,
+        .win7,
+        .win7Sp1,
+        .win8,
+        .win81,
+        .win10,
+        .win10v1511,
+        .win10v1607,
+        .win10v1703,
+        .win10v1709,
+        .win10v1803,
+        .win10v1809,
+        .win10v1903,
+        .win10v1909,
+        .win10v2004,
+        .win10v20H2,
+        .win10v21H1,
+        .win10v21H2,
+        .win10v22H2,
+        .winServer2022,
+        .win11,
+        .win11v22H2,
+        .win11v23H2,
+        .win11v24H2,
+        .win11v25H2,
+        .win11v26H1,
+      ];
+
+      for (var i = 0; i < versions.length - 1; i++) {
+        check(versions[i]).isLessThan(versions[i + 1]);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds `OsVersion`, an immutable value type that provides reliable Windows version detection via [RtlGetVersion](https://learn.microsoft.com/windows/win32/DevNotes/rtlgetversion), bypassing the compatibility shims that cause `GetVersionEx` to report incorrect versions on Windows 8.1 and later.

Includes well-known version constants from `OsVersion.xp` through `OsVersion.win11v26H1` for ergonomic range checks, along with `isServer` for edition detection and `revision` for the full UBR patch number.

## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [ ] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [ ] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
