### PR TITLE
feat(win32): add `GET_X_LPARAM` and `GET_Y_LPARAM` macros

### DIFF
--- a/examples/customtitlebar.dart
+++ b/examples/customtitlebar.dart
@@ -427,8 +427,8 @@ int mainWindowProc(Pointer hWnd, int msg, int wParam, int lParam) {
       final padding = GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi).value;
       final cursorPoint = adaptiveCalloc<POINT>();
       cursorPoint.ref
-        ..x = LOWORD(lParam)
-        ..y = HIWORD(lParam);
+        ..x = GET_X_LPARAM(.new(lParam))
+        ..y = GET_Y_LPARAM(.new(lParam));
 
       try {
         ScreenToClient(hwnd, cursorPoint);

--- a/examples/system_tray_icon/lib/src/window.dart
+++ b/examples/system_tray_icon/lib/src/window.dart
@@ -126,8 +126,8 @@ int _windowProc(Pointer hWnd, int uMsg, int wParam, int lParam) {
         case WM_CONTEXTMENU:
           final window = Win32Window._windowRegistry[hwnd]!;
           window._app.showTrayContextMenu(
-            screenX: LOWORD(wParam),
-            screenY: HIWORD(wParam),
+            screenX: GET_X_LPARAM(.new(wParam)),
+            screenY: GET_Y_LPARAM(.new(wParam)),
           );
           return 0;
 

--- a/packages/win32/lib/src/macros.dart
+++ b/packages/win32/lib/src/macros.dart
@@ -71,7 +71,7 @@ int CTL_CODE(int DeviceType, int Function, int Method, int Access) =>
 ///
 /// [DialogBoxIndirect] does not return control until the specified callback
 /// function terminates the modal dialog box by calling the [EndDialog]
-/// unction.
+/// function.
 ///
 /// To learn more, see
 /// <https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-dialogboxindirectw>.
@@ -135,6 +135,29 @@ int GetBValue(int rgb) => LOBYTE(rgb >> 16);
 // #define GET_SC_WPARAM(wParam) ((int)wParam & 0xFFF0)
 @pragma('vm:prefer-inline')
 int GET_SC_WPARAM(int wParam) => wParam & 0xFFF0;
+
+/// Retrieves the signed x-coordinate from the specified [LPARAM] value.
+///
+/// Use this macro instead of [LOWORD] when extracting cursor x positions from
+/// Windows messages (e.g., [WM_MOUSEMOVE], [WM_LBUTTONDOWN]).
+/// Unlike [LOWORD], this macro correctly returns negative coordinates, which
+/// occur when a secondary display is positioned to the left of the primary
+/// display.
+//
+// #define GET_X_LPARAM(lp)  ((int)(short)LOWORD(lp))
+@pragma('vm:prefer-inline')
+int GET_X_LPARAM(LPARAM lp) => LOWORD(lp).toSigned(16);
+
+/// Retrieves the signed y-coordinate from the specified [LPARAM] value.
+///
+/// Use this macro instead of [HIWORD] when extracting cursor y positions from
+/// Windows messages (e.g., [WM_MOUSEMOVE], [WM_LBUTTONDOWN]).
+/// Unlike [HIWORD], this macro correctly returns negative coordinates, which
+/// occur when a secondary display is positioned above the primary display.
+//
+// #define GET_Y_LPARAM(lp)  ((int)(short)HIWORD(lp))
+@pragma('vm:prefer-inline')
+int GET_Y_LPARAM(LPARAM lp) => HIWORD(lp).toSigned(16);
 
 /// Retrieves the high-order byte from the specified 16-bit value.
 //
@@ -203,7 +226,7 @@ int LOWORD(int l) => l & 0xffff;
 //
 // #define MAKEINTRESOURCEW(i) ((LPWSTR)((ULONG_PTR)((WORD)(i))))
 @pragma('vm:prefer-inline')
-PWSTR MAKEINTRESOURCE(int i) => PWSTR(Pointer.fromAddress(i));
+PWSTR MAKEINTRESOURCE(int i) => .new(Pointer.fromAddress(i));
 
 /// Creates a LONG value by concatenating the specified values.
 //
@@ -233,7 +256,7 @@ void PropVariantInit(Pointer<PROPVARIANT> pvar) =>
 //
 // ((COLORREF)(((BYTE)(r)|((WORD)((BYTE)(g))<<8))|(((DWORD)(BYTE)(b))<<16)))
 @pragma('vm:prefer-inline')
-COLORREF RGB(int r, int g, int b) => COLORREF(r + (g << 8) + (b << 16));
+COLORREF RGB(int r, int g, int b) => .new(r + (g << 8) + (b << 16));
 
 /// Provides a generic test for success on any status value.
 //

--- a/packages/win32/test/win32/macros_test.dart
+++ b/packages/win32/test/win32/macros_test.dart
@@ -130,5 +130,19 @@ void main() {
     test('GET_SC_WPARAM extracts system command WPARAM', () {
       check(GET_SC_WPARAM(SC_CLOSE)).equals(SC_CLOSE);
     });
+
+    test('GET_X_LPARAM extracts signed x-coordinate', () {
+      const lParam1 = LPARAM(0x00640032); // x=50, y=100
+      const lParam2 = LPARAM(0xFF9CFFCE); // x=-50, y=-100
+      check(GET_X_LPARAM(lParam1)).equals(50);
+      check(GET_X_LPARAM(lParam2)).equals(-50);
+    });
+
+    test('GET_Y_LPARAM extracts signed y-coordinate', () {
+      const lParam1 = LPARAM(0x00640032); // x=50, y=100
+      const lParam2 = LPARAM(0xFF9CFFCE); // x=-50, y=-100
+      check(GET_Y_LPARAM(lParam1)).equals(100);
+      check(GET_Y_LPARAM(lParam2)).equals(-100);
+    });
   });
 }


### PR DESCRIPTION
## Description

 Adds [GET_X_LPARAM](https://learn.microsoft.com/en-us/windows/win32/api/windowsx/nf-windowsx-get_x_lparam) and [GET_Y_LPARAM](https://learn.microsoft.com/en-us/windows/win32/api/windowsx/nf-windowsx-get_y_lparam) macros to correctly extract signed x/y coordinates from Windows message parameters.

 `LOWORD`/`HIWORD` return an unsigned 16-bit integer (`WORD`), so negative coordinates — which occur when a secondary display is positioned to the left of or above the primary display — come back as large positive values (e.g., `-100` becomes `65436`). This is not a Dart-specific bug; the same issue exists in C when using `LOWORD`/`HIWORD` directly instead of `GET_X_LPARAM`/`GET_Y_LPARAM`.

The two examples that were extracting cursor positions using `LOWORD`/`HIWORD` have been updated to use the new macros.

## Related Issue

#1071 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [ ] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [ ] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
