### PR TITLE
chore(release): `package:win32` v6.2.0

### DIFF
--- a/packages/win32/CHANGELOG.md
+++ b/packages/win32/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [6.2.0] - 2026-05-07
+
+### 🚀 Features
+
+- Add `OsVersion` class for reliable Windows version detection and OS baseline
+  checks. Use `OsVersion.current` to retrieve the running version and the
+  relational operators (`<`, `<=`, `>=`, `>`) to range-check it against
+  well-known baselines (`OsVersion.win10`, `OsVersion.win11`, etc.).
+
+- Add extension methods on `GUID` for comparison and ordering: `compareTo()`,
+  `isEqualTo()`, and the relational operators (`<`, `<=`, `>=`, `>`). Useful for
+  using `GUID` as a key in sorted collections such as `SplayTreeMap`.
+
+- Add `GET_X_LPARAM()` and `GET_Y_LPARAM()` macros for correctly extracting
+  signed x/y cursor coordinates from Windows message parameters. Unlike
+  `LOWORD()`/`HIWORD()`, these macros handle negative coordinates that occur
+  when a secondary display is positioned to the left of or above the primary
+  display.
+
+### 🐛 Bug Fixes
+
+- Fix `IsWindowsServer()` using the wrong constant.
+
+[6.2.0]: https://github.com/halildurmus/win32/compare/win32-v6.1.0..win32-v6.2.0
+
 ## [6.1.0] - 2026-04-22
 
 ### 🚀 Features

--- a/packages/win32/README.md
+++ b/packages/win32/README.md
@@ -122,6 +122,7 @@ This repository includes a wide range of examples demonstrating real-world
 usage in the [examples directory]:
 
 - **Flutter desktop apps** using native Win32 APIs
+- **Reliable Windows version detection and OS baseline checks**
 - **System information tools**
 - **Traditional Win32 GUI applications written in Dart**
 - **Games using GDI**

--- a/packages/win32/pubspec.yaml
+++ b/packages/win32/pubspec.yaml
@@ -1,6 +1,6 @@
 name: win32
 description: Call common Windows APIs directly from Dart using FFI.
-version: 6.1.0
+version: 6.2.0
 homepage: https://win32.pub
 repository: https://github.com/halildurmus/win32
 issue_tracker: https://github.com/halildurmus/win32/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22package%3A%20win32%22


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the
  title.

  Please look at the following checklist to ensure that your PR can be accepted
  quickly:
-->

## Description

## [6.2.0] - 2026-05-07

### 🚀 Features

- Add `OsVersion` class for reliable Windows version detection and OS baseline
  checks. Use `OsVersion.current` to retrieve the running version and the
  relational operators (`<`, `<=`, `>=`, `>`) to range-check it against
  well-known baselines (`OsVersion.win10`, `OsVersion.win11`, etc.).

- Add extension methods on `GUID` for comparison and ordering: `compareTo()`,
  `isEqualTo()`, and the relational operators (`<`, `<=`, `>=`, `>`). Useful for
  using `GUID` as a key in sorted collections such as `SplayTreeMap`.

- Add `GET_X_LPARAM()` and `GET_Y_LPARAM()` macros for correctly extracting
  signed x/y cursor coordinates from Windows message parameters. Unlike
  `LOWORD()`/`HIWORD()`, these macros handle negative coordinates that occur
  when a secondary display is positioned to the left of or above the primary
  display.

### 🐛 Bug Fixes

- Fix `IsWindowsServer()` using the wrong constant.

## Related Issue

#1071

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [ ] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [x] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
